### PR TITLE
Feature/separate workflow for main and release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: "Release"
 on:
   push:
     branches:
-      - release
+      - main
 
 jobs:
   publish-tauri:
@@ -39,8 +39,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: noter-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
-          releaseName: 'Noter v__VERSION__'
+          tagName: noter-draft-${{ github.run_number }}
+          releaseName: 'Noter draft ${{ github.run_number }}'
           releaseBody: 'See the assets to download this version and install.'
-          releaseDraft: false
+          releaseDraft: true
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,22 @@ on:
       - release
 
 jobs:
+  check-release-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check Cargo.toml Version
+        run: |
+          if git diff HEAD^ HEAD -- src-tauri/Cargo.toml | grep -qE '^[-+]{1}version = "[0-9.]+"'; then
+            echo "Cargo.toml version has been updated."
+          else
+            echo "Cargo.toml version has not been updated. Please update the version number in Cargo.toml."
+            exit 1
+          fi
+
   publish-tauri:
+    needs: check-release-version
     permissions:
       contents: write
     strategy:


### PR DESCRIPTION
From now on, main will create draft releases, and release branch will create the official releases... 
It sounds more convenient to have main as occasional point of pushing final commits without testing them officially. 
Main would be merged to release branch only when we have tested the draft release from main branch...
