### PR TITLE
Ability to zoom using ctrl + scroll

### DIFF
--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -14,7 +14,7 @@ import { useCustomTheme } from '~/hooks/useCustomTheme'
 
 import { ThemeType } from '~/config/allThemes'
 import { customSyntaxHighlighting } from '~/components/Editor/customSyntaxHighlighting'
-import { setZoomEvent } from '~/components/Editor/extensions/zoomExtension'
+import { setZoomEvent } from '~/components/Editor/helpers/setZoomEvent'
 
 const Editor = (): ReactElement => {
   const editorRef = useRef<HTMLDivElement>(null)

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -14,6 +14,7 @@ import { useCustomTheme } from '~/hooks/useCustomTheme'
 
 import { ThemeType } from '~/config/allThemes'
 import { customSyntaxHighlighting } from '~/components/Editor/customSyntaxHighlighting'
+import { setZoomEvent } from '~/components/Editor/extensions/zoomExtension'
 
 const Editor = (): ReactElement => {
   const editorRef = useRef<HTMLDivElement>(null)
@@ -22,6 +23,8 @@ const Editor = (): ReactElement => {
   } = useCustomTheme()
 
   useEffect(() => {
+    if (editorRef.current === null) return
+
     const view = new EditorView({
       state: EditorState.create({
         doc: sampleNote,
@@ -44,8 +47,11 @@ const Editor = (): ReactElement => {
           }),
         ],
       }),
-      parent: editorRef.current as HTMLDivElement,
+      parent: editorRef.current,
     })
+
+    setZoomEvent(localStorage, view)
+
     return () => {
       view.destroy()
     }

--- a/src/components/Editor/extensions/zoomExtension.ts
+++ b/src/components/Editor/extensions/zoomExtension.ts
@@ -1,0 +1,37 @@
+import { type EditorView } from 'codemirror'
+import { type WheelEvent } from 'react'
+
+const minFontSize = 8
+const maxFontSize = 60
+
+export const setZoomEvent = (
+  localStorage: Storage,
+  editorElement: EditorView
+): void => {
+  const storedFontSize = parseInt(localStorage.getItem('fontSize') ?? '14')
+  editorElement.dom.style.fontSize = `${storedFontSize}px`
+
+  const element = editorElement.dom.querySelector('.cm-scroller')
+  if (element == null) return
+
+  element.addEventListener('wheel', (e) => {
+    const event = e as unknown as WheelEvent
+    if (!event.ctrlKey) return
+
+    event.preventDefault()
+
+    let fontSize = parseFloat(editorElement.dom.style.fontSize)
+    if (isNaN(fontSize)) {
+      fontSize = storedFontSize
+    }
+
+    if (event.deltaY < 0) {
+      fontSize = Math.min(fontSize + 1, maxFontSize)
+    } else {
+      fontSize = Math.max(fontSize - 1, minFontSize)
+    }
+
+    editorElement.dom.style.fontSize = `${fontSize}px`
+    localStorage.setItem('fontSize', `${fontSize}`)
+  })
+}

--- a/src/components/Editor/helpers/setZoomEvent.ts
+++ b/src/components/Editor/helpers/setZoomEvent.ts
@@ -16,7 +16,7 @@ export const setZoomEvent = (
 
   element.addEventListener('wheel', (e) => {
     const event = e as unknown as WheelEvent
-    if (!event.ctrlKey) return
+    if (!(event.ctrlKey || event.metaKey)) return
 
     event.preventDefault()
 

--- a/src/e2e/editor.spec.ts
+++ b/src/e2e/editor.spec.ts
@@ -17,7 +17,7 @@ test.describe('editor tests', () => {
     const fontSize = await getStyle(textSelector, 'font-size')
     const fontWeight = await getStyle(textSelector, 'font-weight')
 
-    expect(fontSize).toBe('16px')
+    expect(fontSize).toBe('14px')
     expect(fontWeight).toBe('400')
   })
 
@@ -37,7 +37,7 @@ test.describe('editor tests', () => {
     const fontWeight = await getStyle(headingSelector, 'font-weight')
 
     expect(fontWeight).toBe('700')
-    expect(fontSize).toBe(26)
+    expect(fontSize).toBe(22)
   })
 
   test('can create bold text', async ({ page }) => {
@@ -193,5 +193,50 @@ test.describe('editor tests', () => {
     await page.keyboard.press(`${getCtrlOrMetaKey()}+Enter`)
 
     await expect(page.getByText('- [x]')).toHaveCount(3)
+  })
+
+  test('can zoom using ctrl + scroll which persists on app reload', async ({
+    page,
+  }) => {
+    await page.goto('/')
+
+    await page.click('.cm-editor')
+    await page.keyboard.press(`${getCtrlOrMetaKey()}+A`)
+    await page.keyboard.press('Backspace')
+
+    const text = 'This is text at normal font size'
+    await page.keyboard.type(text)
+    const textSelector = page.getByText(text)
+
+    const fontSize = await getStyle(textSelector, 'font-size').then((size) =>
+      Math.round(parseFloat(size))
+    )
+    expect(fontSize).toBe(14)
+
+    await page.keyboard.down(getCtrlOrMetaKey())
+    await page.mouse.wheel(0, -1)
+    await page.mouse.wheel(0, -1)
+    await page.mouse.wheel(0, -1)
+    await page.keyboard.up(getCtrlOrMetaKey())
+
+    const fontSize2 = await getStyle(textSelector, 'font-size').then((size) =>
+      Math.round(parseFloat(size))
+    )
+    expect(fontSize2).toBe(17)
+
+    await page.goto('/')
+
+    await page.click('.cm-editor')
+    await page.keyboard.press(`${getCtrlOrMetaKey()}+A`)
+    await page.keyboard.press('Backspace')
+
+    const text2 = 'This text should be in the new font size'
+    await page.keyboard.type(text2)
+    const textSelector2 = page.getByText(text2)
+
+    const fontSize3 = await getStyle(textSelector2, 'font-size').then((size) =>
+      Math.round(parseFloat(size))
+    )
+    expect(fontSize3).toBe(17)
   })
 })


### PR DESCRIPTION
users can now scroll using ctrl + scroll which persists across app restarts...

Tried various method to do it in a better way including creating a custom extension (failed because domEventHandler provided by codemirror only works in the scroll event in the 'written' area of the editor. If the user scrolled outside it, this was not getting triggered. There was no simple way to solve this as well)

Even though this method seems to be adding 'multiple' event handlers everytime useEffect is called, I tested it and verified that somehow the scroll event is only being called once. So everything is fine... 