### PR TITLE
feat: redo using ctrl shift z

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@chakra-ui/icons": "^2.0.17",
     "@chakra-ui/react": "^2.8.1",
+    "@codemirror/commands": "^6.3.0",
     "@codemirror/lang-markdown": "^6.1.1",
     "@codemirror/language": "^6.7.0",
     "@codemirror/language-data": "^6.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   '@chakra-ui/react':
     specifier: ^2.8.1
     version: 2.8.1(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.15)(framer-motion@10.12.21)(react-dom@18.2.0)(react@18.2.0)
+  '@codemirror/commands':
+    specifier: ^6.3.0
+    version: 6.3.0
   '@codemirror/lang-markdown':
     specifier: ^6.1.1
     version: 6.2.0
@@ -1542,13 +1545,13 @@ packages:
       '@lezer/common': 1.1.0
     dev: false
 
-  /@codemirror/commands@6.2.4:
-    resolution: {integrity: sha512-42lmDqVH0ttfilLShReLXsDfASKLXzfyC36bzwcqzox9PlHulMcsUOfHXNo2X2aFMVNUoQ7j+d4q5bnfseYoOA==}
+  /@codemirror/commands@6.3.0:
+    resolution: {integrity: sha512-tFfcxRIlOWiQDFhjBSWJ10MxcvbCIsRr6V64SgrcaY0MwNk32cUOcCuNlWo8VjV4qRQCgNgUAnIeo0svkk4R5Q==}
     dependencies:
       '@codemirror/language': 6.8.0
       '@codemirror/state': 6.2.1
       '@codemirror/view': 6.14.1
-      '@lezer/common': 1.0.3
+      '@lezer/common': 1.1.0
     dev: false
 
   /@codemirror/lang-angular@0.1.2:
@@ -2257,7 +2260,7 @@ packages:
   /@lezer/html@1.3.6:
     resolution: {integrity: sha512-Kk9HJARZTc0bAnMQUqbtuhFVsB4AnteR2BFUWfZV7L/x1H0aAKz6YabrfJ2gk/BEgjh9L3hg5O4y2IDZRBdzuQ==}
     dependencies:
-      '@lezer/common': 1.0.3
+      '@lezer/common': 1.1.0
       '@lezer/highlight': 1.1.6
       '@lezer/lr': 1.3.9
     dev: false
@@ -3171,7 +3174,7 @@ packages:
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
     dependencies:
       '@codemirror/autocomplete': 6.8.1(@codemirror/language@6.8.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.1)(@lezer/common@1.1.0)
-      '@codemirror/commands': 6.2.4
+      '@codemirror/commands': 6.3.0
       '@codemirror/language': 6.8.0
       '@codemirror/lint': 6.4.0
       '@codemirror/search': 6.5.0

--- a/src/components/Editor/customKeymap.ts
+++ b/src/components/Editor/customKeymap.ts
@@ -1,5 +1,6 @@
 import { Prec } from '@codemirror/state'
 import { keymap } from '@codemirror/view'
+import { redo } from '@codemirror/commands'
 import {
   modifyLines,
   modifySelection,
@@ -45,6 +46,16 @@ export default Prec.highest(
       key: 'Mod-Shift-Enter',
       run: (editor) => {
         modifyLines(editor.state, editor.dispatch, toggleCheckListAll)
+        return true
+      },
+    },
+    {
+      key: 'Mod-Shift-z',
+      run: (editor) => {
+        redo({
+          state: editor.state,
+          dispatch: editor.dispatch,
+        })
         return true
       },
     },


### PR DESCRIPTION
Not really a big deal. There was redo already but with a different keybinding. Just assinged an appropriate and natural keybind `ctrl-shift-z` to it.